### PR TITLE
Add JamBrains to the implementers DAO

### DIFF
--- a/docs/dao/index.md
+++ b/docs/dao/index.md
@@ -35,6 +35,7 @@ This section functions as the single source of truth of JAM Implementer DAO Memb
 | JAMdotTech \| PyJAMaz | 15gPiSBxhrrQFfShFbrnsQK7kokgQtVs3SEh38YjCDC31de3 | [Link](https://polkadot.subscan.io/extrinsic/25331656-2) |
 | MORUM | 123KEnwuHKiu48WsfwAX4YonGFTpkEmWS6V2WGoJA1qzBkbS | [Link](https://polkadot.subscan.io/extrinsic/25330323-2) |
 | Tessera | 15p3jWZaP4dHTkDTuKM5VXQL5XGfH9U5r6Ntu3UAv2K7vPb8 | [Link](https://polkadot.subscan.io/extrinsic/25331398-2) |
+| JamBrains | 15R1pWegyu7AfMev8DBMT67qxYoJhA1v7BbA2nn7S2uJ5QDF | [Link](https://assethub-polkadot.subscan.io/extrinsic/8512653-2) |
 
 <details>
 <summary>Raw YAML</summary>
@@ -80,6 +81,9 @@ members:
   - name: "Tessera"
     address: "15p3jWZaP4dHTkDTuKM5VXQL5XGfH9U5r6Ntu3UAv2K7vPb8"
     extrinsic: "https://polkadot.subscan.io/extrinsic/25331398-2"
+  - name: "JamBrains"
+    address: "15R1pWegyu7AfMev8DBMT67qxYoJhA1v7BbA2nn7S2uJ5QDF"
+    extrinsic: "https://assethub-polkadot.subscan.io/extrinsic/8512653-2"
 
 ```
 

--- a/docs/dao/members.yml
+++ b/docs/dao/members.yml
@@ -38,3 +38,6 @@ members:
   - name: "Tessera"
     address: "15p3jWZaP4dHTkDTuKM5VXQL5XGfH9U5r6Ntu3UAv2K7vPb8"
     extrinsic: "https://polkadot.subscan.io/extrinsic/25331398-2"
+  - name: "JamBrains"
+    address: "15R1pWegyu7AfMev8DBMT67qxYoJhA1v7BbA2nn7S2uJ5QDF"
+    extrinsic: "https://assethub-polkadot.subscan.io/extrinsic/8512653-2"


### PR DESCRIPTION
I'm adding `JamBrains` to the JAM implementers DAO based on this extrinsic: https://assethub-polkadot.subscan.io/extrinsic/8512653-2