### PR TITLE
Add EC related parameters

### DIFF
--- a/docs/knowledge/basics/chain-spec/2xlarge.md
+++ b/docs/knowledge/basics/chain-spec/2xlarge.md
@@ -9,12 +9,13 @@ slug: /basics/chain-spec/2xlarge
 
 ```yaml
 chain: 2xlarge
-num_validators: 384
-num_cores: 128
+num_validators: 342
+num_cores: 114
 slot_duration: 6
 epoch_duration: 300
 contest_duration: 250
 tickets_per_validator: 2
 max_tickets_per_extrinsic: 16
 rotation_period: TODO
+num_ec_pieces_per_segment: 18
 ```

--- a/docs/knowledge/basics/chain-spec/3xlarge.md
+++ b/docs/knowledge/basics/chain-spec/3xlarge.md
@@ -9,14 +9,15 @@ slug: /basics/chain-spec/3xlarge
 
 ```yaml
 chain: 3xlarge
-num_validators: 576
-num_cores: 192
+num_validators: 684
+num_cores: 228
 slot_duration: 6
 epoch_duration: 600
 contest_duration: 500
 tickets_per_validator: 2
 max_tickets_per_extrinsic: 16
 rotation_period: TODO
+num_ec_pieces_per_segment: 9
 ```
 
 * The epochs are 30 minutes rather than the full hour of the toaster.  

--- a/docs/knowledge/basics/chain-spec/index.md
+++ b/docs/knowledge/basics/chain-spec/index.md
@@ -50,3 +50,7 @@ The rotation period of validator-core assignments, in timeslots.
 
 The maximum number of tickets which may be submitted in a single extrinsic.  
 Constraint: $\mathsf{K} > 0$
+
+### WP `num_ec_pieces_per_segment`
+
+The number of erasure-coded pieces in a segment

--- a/docs/knowledge/basics/chain-spec/large.md
+++ b/docs/knowledge/basics/chain-spec/large.md
@@ -9,12 +9,13 @@ slug: /basics/chain-spec/large
 
 ```yaml
 chain: large
-num_validators: 96
-num_cores: 32
+num_validators: 36
+num_cores: 12
 slot_duration: 6
 epoch_duration: 120
 contest_duration: 100
 tickets_per_validator: 2
 max_tickets_per_extrinsic: 3
 rotation_period: TODO
+num_ec_pieces_per_segment: 171
 ```

--- a/docs/knowledge/basics/chain-spec/medium.md
+++ b/docs/knowledge/basics/chain-spec/medium.md
@@ -9,12 +9,13 @@ slug: /basics/chain-spec/medium
 
 ```yaml
 chain: medium
-num_validators: 48
-num_cores: 16
+num_validators: 18
+num_cores: 6
 slot_duration: 6
 epoch_duration: 60
 contest_duration: 50
 tickets_per_validator: 2
 max_tickets_per_extrinsic: 3
 rotation_period: TODO
+num_ec_pieces_per_segment: 342
 ```

--- a/docs/knowledge/basics/chain-spec/small.md
+++ b/docs/knowledge/basics/chain-spec/small.md
@@ -9,12 +9,13 @@ slug: /basics/chain-spec/small
 
 ```yaml
 chain: small
-num_validators: 24
-num_cores: 8
+num_validators: 12
+num_cores: 4
 slot_duration: 6
 epoch_duration: 36
 contest_duration: 30
 tickets_per_validator: 2
 max_tickets_per_extrinsic: 3
 rotation_period: TODO
+num_ec_pieces_per_segment: 513
 ```

--- a/docs/knowledge/basics/chain-spec/tiny.md
+++ b/docs/knowledge/basics/chain-spec/tiny.md
@@ -19,6 +19,7 @@ contest_duration: 10
 tickets_per_validator: 3
 max_tickets_per_extrinsic: 3
 rotation_period: 4
+num_ec_pieces_per_segment: 1026
 ```
 
 Please consult a few other JAM implementer teams before changing this spec, as it is in use for

--- a/docs/knowledge/basics/chain-spec/toaster.md
+++ b/docs/knowledge/basics/chain-spec/toaster.md
@@ -17,6 +17,7 @@ epoch_duration: 600
 contest_duration: 500
 tickets_per_validator: 2
 rotation_period: 10
+num_ec_pieces_per_segment: 6
 ```
 
 The "full" name comes from the fact that full takes up the entire JAM "Toaster".

--- a/docs/knowledge/basics/chain-spec/xlarge.md
+++ b/docs/knowledge/basics/chain-spec/xlarge.md
@@ -9,13 +9,14 @@ slug: /basics/chain-spec/xlarge
 
 ```yaml
 chain: xlarge
-num_validators: 192
-num_cores: 64
+num_validators: 108
+num_cores: 36
 slot_duration: 6
 epoch_duration: 240
 contest_duration: 200
 tickets_per_validator: 2
 rotation_period: TODO
+num_ec_pieces_per_segment: 57
 ```
 
 * The JAM Toaster can support 5 XLarge configurations.


### PR DESCRIPTION
Add the WP parameter (num_ec_pieces_per_segment) to ensure that all network settings yield a consistent G size of 4104:

| Network      | V    | C   | WP   |
|--------------|:------:|:-----:|:------:|
| **tiny**         | 6    | 2   | 1026 |
| **small**        | 12   | 4   | 513  |
| **medium**       | 18   | 6   | 342  |
| **large**        | 36   | 12  | 171  |
| **xlarge**       | 108  | 36  | 57   |
| **2xlarge**      | 342  | 114 | 18   |
| **3xlarge**      | 684  | 228 | 9    |
| **full/toaster** | 1023 | 341 | 6    |


**Notes:** 
	•	In most network settings,  3 * C = V (i.e. three times the number of cores equals the number of validators). Additionally, 2 * C * WP = G (4104), or C * WP = 2052.  For example, - In **tiny**: 2 * 1026 = 2052; In **small**: 4 * 513 = 2052....

**Exception**: The **Full/Toaster** network setting’s V and C values are rounded down from (V = 342, C = 1026) to (C = 341, V = 1023) in order to satisfy the ringSet constraint of num_validators <= 1023. This results in 341 * 6 = 2046, which is slightly less than 2052. In other words, **Full/Toaster**'s EC are encoded in a way that shard_index of [1023, 1024 1025] are **dropped/ignored/not distributed/** to any DA.
